### PR TITLE
Transpile es module build

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -15,6 +15,9 @@
       "presets": ["minify"],
       "plugins": ["external-helpers"]
     },
+    "es": {
+      "plugins": ["external-helpers"]
+    },
     "test": {
       "presets": ["env", "react"]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 dist
+es
 examples/build
 coverage

--- a/package.json
+++ b/package.json
@@ -3,13 +3,14 @@
   "version": "0.0.2",
   "description": "Selector component for Redux state using render props.",
   "main": "dist/redux-render.js",
-  "module": "src/index.js",
+  "module": "es/index.js",
   "author": "Jason Nall <jsonnull@gmail.com>",
   "license": "MIT",
   "scripts": {
     "build:umd": "cross-env BABEL_ENV=development NODE_ENV=development rollup -c -o dist/redux-render.js",
     "build:umd:min": "cross-env BABEL_ENV=production NODE_ENV=production rollup -c -o dist/redux-render.min.js",
-    "build": "npm run build:umd && npm run build:umd:min",
+    "build:es": "cross-env BABEL_ENV=es NODE_ENV=es rollup -c -o es/redux-render.js",
+    "build": "npm run build:umd && npm run build:umd:min && npm run build:es",
     "test": "jest",
     "test:coverage": "jest --coverage && cat ./coverage/lcov.info | coveralls"
   },
@@ -18,8 +19,9 @@
     "url": "https://github.com/jsonnull/redux-render.git"
   },
   "files": [
+    "src",
     "dist",
-    "src"
+    "es"
   ],
   "keywords": [
     "react",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,11 +12,22 @@ const config = {
     react: 'React',
     redux: 'Redux'
   },
-  output: {
-    format: 'umd'
-  },
   name: 'ReduxRender',
-  plugins: [
+  plugins: []
+}
+
+if (env === 'es') {
+  config.output = {
+    format: 'es'
+  }
+  config.plugins.push(babel())
+}
+
+if (env === 'development' || env === 'production') {
+  config.output = {
+    format: 'umd'
+  }
+  config.plugins.push(
     nodeResolve(),
     babel({
       exclude: '**/node_modules/**'
@@ -25,7 +36,7 @@ const config = {
       'process.env.NODE_ENV': JSON.stringify(env)
     }),
     commonjs()
-  ]
+  )
 }
 
 export default config


### PR DESCRIPTION
Looks like even the scripts used by the `module` field may not be transpiled. Notably, this is the current behavior of create-react-app when building.

So now a transpiled version which supports ES modules is made available.

Fixes #4 